### PR TITLE
Make `rand` compatible with MeasureBase

### DIFF
--- a/src/primitives/rand.jl
+++ b/src/primitives/rand.jl
@@ -16,13 +16,27 @@ end
     rand(GLOBAL_RNG, T_rng, m, args...; kwargs...)
 end
 
-@inline function Base.rand(rng::AbstractRNG, ::Type{T_rng}, d::AbstractConditionalModel, N::Int) where {T_rng}
+@inline function Base.rand(m::AbstractConditionalModel, d::Integer, dims::Integer...; kwargs...) 
+    rand(GLOBAL_RNG, Float64, m, d, dims...; kwargs...)
+end
+
+@inline function Base.rand(rng::AbstractRNG, m::AbstractConditionalModel, d::Integer, dims::Integer...; kwargs...) 
+    rand(rng, Float64, m, d, dims...; kwargs...)
+end
+
+@inline function Base.rand(::Type{T_rng}, m::AbstractConditionalModel, d::Integer, dims::Integer...; kwargs...) where {T_rng}
+    rand(GLOBAL_RNG, T_rng, m, d, dims...; kwargs...)
+end
+
+@inline function Base.rand(rng::AbstractRNG, ::Type{T_rng}, d::AbstractConditionalModel, N::Integer, v::Vararg{Integer}) where {T_rng}
+    @assert isempty(v)
     r = chainvec(rand(rng, T_rng, d), N)
     for j in 2:N
         @inbounds r[j] = rand(rng, T_rng, d)
     end
     return r
 end
+
 
 @inline function Base.rand(rng::AbstractRNG, ::Type{T_rng}, m::AbstractConditionalModel; ctx=NamedTuple(), retfun = (r, ctx) -> r) where {T_rng}
     cfg = (rng=rng, T_rng=T_rng)

--- a/src/primitives/rand.jl
+++ b/src/primitives/rand.jl
@@ -17,7 +17,7 @@ end
 end
 
 @inline function Base.rand(rng::AbstractRNG, ::Type{T_rng}, d::AbstractConditionalModel, N::Int) where {T_rng}
-    r = chainvec(rand(rng, d), N)
+    r = chainvec(rand(rng, T_rng, d), N)
     for j in 2:N
         @inbounds r[j] = rand(rng, T_rng, d)
     end

--- a/src/primitives/rand.jl
+++ b/src/primitives/rand.jl
@@ -4,22 +4,28 @@ using TupleVectors: chainvec
 export rand
 EmptyNTtype = NamedTuple{(),Tuple{}} where T<:Tuple
 
-@inline function Base.rand(rng::AbstractRNG, d::AbstractConditionalModel, N::Int)
+@inline function Base.rand(m::AbstractConditionalModel, args...; kwargs...) 
+    rand(GLOBAL_RNG, Float64, m, args...; kwargs...)
+end
+
+@inline function Base.rand(rng::AbstractRNG, m::AbstractConditionalModel, args...; kwargs...) 
+    rand(rng, Float64, m, args...; kwargs...)
+end
+
+@inline function Base.rand(::Type{T_rng}, m::AbstractConditionalModel, args...; kwargs...) where {T_rng}
+    rand(GLOBAL_RNG, T_rng, m, args...; kwargs...)
+end
+
+@inline function Base.rand(rng::AbstractRNG, ::Type{T_rng}, d::AbstractConditionalModel, N::Int) where {T_rng}
     r = chainvec(rand(rng, d), N)
     for j in 2:N
-        @inbounds r[j] = rand(rng, d)
+        @inbounds r[j] = rand(rng, T_rng, d)
     end
     return r
 end
 
-@inline Base.rand(d::AbstractConditionalModel, N::Int) = rand(GLOBAL_RNG, d, N)
-
-@inline function Base.rand(m::AbstractConditionalModel; kwargs...) 
-    rand(GLOBAL_RNG, m; kwargs...)
-end
-
-@inline function Base.rand(rng::AbstractRNG, m::AbstractConditionalModel; ctx=NamedTuple(), retfun = (r, ctx) -> r)
-    cfg = (rng=rng,)
+@inline function Base.rand(rng::AbstractRNG, ::Type{T_rng}, m::AbstractConditionalModel; ctx=NamedTuple(), retfun = (r, ctx) -> r) where {T_rng}
+    cfg = (rng=rng, T_rng=T_rng)
     gg_call(rand, m, NamedTuple(), cfg, ctx, retfun)
 end
 
@@ -40,7 +46,7 @@ end
 # ctx::Dict
 
 @inline function tilde(::typeof(Base.rand), lens::typeof(identity), xname, x, d, cfg, ctx::Dict)
-    x = rand(cfg.rng, d)
+    x = rand(cfg.rng, cfg.T_rng, d)
     ctx[dynamic(xname)] = x 
     (x, ctx, nothing)
 end


### PR DESCRIPTION
MeasureBase expects `rand` for `<:AbstractMeasure`s to be set up in terms of
```julia
rand(::AbstractRNG, ::Type{T}, ::AbstractMeasure) where {T}
```

This PR makes Tilde work the same way, allowing conditional models to work with MeasureBase combinators. For example,
```julia
julia> cauchy = @model begin
           a ~ Normal()
           b ~ Normal()
           return a/b
       end;

julia> rand(cauchy() ^ 10)
10-element Vector{Float64}:
  34.0081
  -1.59653
   0.532324
  -1.4452
  -0.34857
  -3.73643
 -10.2925
   0.652122
   0.698344
   0.435826
```